### PR TITLE
Things are working on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,15 @@ source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE VTIL)
 
+if(WIN32)
+    set(EXTENSION ".pyd")
+else()
+	set(EXTENSION ".so")
+endif()
+
 install(PROGRAMS
     $<TARGET_FILE:${PROJECT_NAME}>
     DESTINATION .
     COMPONENT pyd
-    RENAME vtil.pyd
+    RENAME vtil${EXTENSION}
     )

--- a/src/architecture/arch/instruction_desc.hpp
+++ b/src/architecture/arch/instruction_desc.hpp
@@ -42,6 +42,7 @@
 
 #include <vtil/vtil>
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 
 using namespace vtil;
 namespace py = pybind11;
@@ -95,9 +96,9 @@ namespace vtil::python
 
 				.def( "__repr__", &instruction_desc::to_string )
 				.def( "__str__", &instruction_desc::to_string )
-				.def( "__eq__", &instruction_desc::operator== )
-				.def( "__ne__", &instruction_desc::operator!= )
-				.def( "__lt__", &instruction_desc::operator< )
+				.def( py::self == py::self )
+				.def( py::self != py::self )
+				.def( py::self < py::self )
 
 				// End
 				//

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -40,6 +40,7 @@
 // |                         | https://github.com/keystone-engine/keystone/   |
 // |--------------------------------------------------------------------------|
 //
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/tests/arm64/sample.py
+++ b/tests/arm64/sample.py
@@ -21,7 +21,7 @@ def main():
        .sub(t0, 100)    \
        .te(zf, t0, 0)
     
-    print(f'jz taken: {tracer()(variable(bbl.end(), zf))}')
+    print('jz taken: {}'.format(tracer()(variable(bbl.end(), zf))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tested with python 2.7

Because there is no function overloading in python you cannot have `basic_block.begin`, it's been renamed to `basic_block.create`.